### PR TITLE
Added README and minor setup fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.23.0",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.18.0",
     "babel-preset-stage-3": "^6.17.0",

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,31 @@
+# Testing Parity Smart Contracts
+
+BEFORE TESTING: ensure your test environment is properly setup for Babel and its ES2015 modules
+
+```
+cd /path/to/parity/contracts
+npm install [-g] --save-dev . 
+```
+
+This will install necessary dependencies, and configure Babel to transpile JavaScript according to ES2015 specs (e.g. needed for `import {} from ""` syntax).
+
+## Test Suite Layout
+
+## Running Coverage Tests with solidity-coverage
+
+## Running Unit & Integration Tests with Truffle
+
+Make sure that you are in the contracts' base directory, and that your node/babel/truffle environment is configured correctly.
+
+Then run:
+```
+truffle test
+```
+
+This will run all JavaScript tests Truffle recognizes under the `test` directory.
+
+## Running Integration Tests with Truffle
+
+## Running Fuzz Tests with Solfuzz
+
+## Running Security Tests with ManticoreEVM

--- a/test/unit/MultisigWalletTest.js
+++ b/test/unit/MultisigWalletTest.js
@@ -1,5 +1,5 @@
-import {increaseTimeTo, duration} from './helpers/increaseTime.js';
-import {assertEvent, assertNoEvent} from "./helpers/assertEvent";
+import {increaseTimeTo, duration} from '../helpers/increaseTime.js';
+import {assertEvent, assertNoEvent} from '../helpers/assertEvent.js';
 
 const Promise = require("bluebird");
 const Wallet = artifacts.require("./Wallet.sol");

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,6 +1,3 @@
-require('babel-register');
-require('babel-polyfill');
-
 module.exports = {
   networks: {
     development: {

--- a/truffle.js
+++ b/truffle.js
@@ -1,0 +1,5 @@
+require('babel-register');
+require('babel-polyfill');
+
+module.exports = {
+};


### PR DESCRIPTION
I added a README to point out some gotchas I ran into getting a working setup. 
Also includes a basic command to run Truffle tests, and a package.json to make installing npm dependencies easier.

Changes the file structure a little bit for organizational reasons, let me know if you want me to change it back. 

Figured it made sense to keep all the tests under the `test` dir, where Truffle tests will live
under the `test/integration` and `test/unit` subdirectories.